### PR TITLE
0.18.1

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -8,6 +8,7 @@ from api.serializers import EnvironmentsSerializer, TestsStorageSerializer
 from django.http import Http404
 
 class Environment(APIView):
+    authentication_classes = [SessionAuthentication]
     permission_classes = (IsAuthenticated, IsAdminUser)
 
     def get_object(self, pk):

--- a/loader/methods/nose2.py
+++ b/loader/methods/nose2.py
@@ -148,50 +148,56 @@ class Nose2Loader:
                 self.redis.lrem("running_jobs", 0, job)
                 self.redis.delete("job_" + self.data['job_id'])
 
-                # in case if 'stopTestRun' was caught, but some running test exists
-                if job_object.tests_in_progress is not None:
-                    tests = job_object.tests.filter(status=2)  # 'In progress' tests must become 'Aborted'
-                    aborted_tests = 0
-                    for test in tests:
-                        test.status = 6
-                        test.save()
-                        aborted_tests += 1
-                    job_object.status = 3   # Failed
-                    job_object.tests_aborted = aborted_tests
-                # in case if 'stopTestRun' was caught and at least one test was failed
-                elif job_object.tests_failed is not None:
-                    job_object.status = 3   # Failed
-                # in case if 'stopTestRun' was caught and at least one test was aborted
-                elif job_object.tests_aborted is not None:
-                    job_object.status = 3   # Failed
-                # in case if 'stopTestRun' was caught and some tests remain not started
-                else:
-                    if job_object.tests_not_started is not None:
-                        tests = job_object.tests.filter(status=1)
-                        tests_not_started = 0
+                failed = job_object.tests_failed
+                not_started = job_object.tests_not_started
+
+                # If any "aborted" test case:
+                # Job status = Aborted
+                # Every "in progress" tests becomes - aborted
+
+                tests = job_object.tests.filter(status=2)
+                if job_object.tests.filter(status=6).first():
+                    job_object.status = 4
+                    if tests:
+                        aborted_tests = 0
                         for test in tests:
-                            tests_not_started += 1
-                        job_object.tests_not_started = tests_not_started
-                        job_object.status = 3   # Failed
-                    if job_object.tests_skipped is not None:
-                        # No fails, passed exist
-                        if job_object.tests_not_started is None and \
-                                job_object.tests_aborted is None and \
-                                job_object.tests_failed is None and \
-                                job_object.tests_passed is not None:
-                            job_object.status = 2   # Passed
-                        # Fails exist
-                        elif job_object.tests_not_started is not None or \
-                                job_object.tests_aborted is not None or \
-                                job_object.tests_failed is not None:
-                            job_object.status = 3  # Failed
-                        else:
-                            # No passed, no fails
-                            job_object.status = 5  # Skipped
+                            test.status = 6
+                            test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                            test.time_taken = test.stop_time - test.start_time
+                            test.save()
+                            aborted_tests += 1
+                        job_object.tests_aborted = aborted_tests
+                # If any "failed" test case:
+                # Job status = Failed
+                # Every "in progress" tests becomes - aborted
+                elif failed:
+                    job_object.status = 3
+                    if tests:
+                        aborted_tests = 0
+                        for test in tests:
+                            test.status = 6
+                            test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                            test.time_taken = test.stop_time - test.start_time
+                            test.save()
+                            aborted_tests += 1
+                        job_object.tests_aborted = aborted_tests
+                else:
+                    # If no "failed" test cases, but "not started" remain - job will be "Failed"
+                    if not_started:
+                        if tests:
+                            aborted_tests = 0
+                            for test in tests:
+                                test.status = 6
+                                test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                                test.time_taken = test.stop_time - test.start_time
+                                test.save()
+                                aborted_tests += 1
+                            job_object.tests_aborted = aborted_tests
+                        job_object.status = 3
+                    # If no "failed" (and other negative variations) test cases - job will be "Passed"
                     else:
-                        # if no tests with 'failed', 'aborted' or 'running' states after 'stopTestRun' signal -
-                        # mark job as 'Passed'
-                        job_object.status = 2   # Passed
+                        job_object.status = 2
+
                 job_object.stop_time = unix_time_to_datetime(self.data['stopTime'])
                 job_object.time_taken = job_object.stop_time - job_object.start_time
 
@@ -230,7 +236,7 @@ class Nose2Loader:
 
             if job_object.status == 1:
                 try:
-                    test = Tests.objects.get(test__identity=self.data['test'], job=job_object)
+                    test = Tests.objects.get(uuid=self.data['uuid'], job=job_object)
                     test.status = 2
                     test.start_time = unix_time_to_datetime(self.data['startTime'])
                     test.save()
@@ -256,7 +262,7 @@ class Nose2Loader:
             job_object = TestJobs.objects.get(uuid=self.data['job_id'])
             if job_object.status == 1:
                 try:
-                    test = Tests.objects.get(test__identity=self.data['test'], job=job_object)
+                    test = Tests.objects.get(uuid=self.data['uuid'], job=job_object)
                     if self.data['status'] == "passed":
                         test.status = 3
                         if not job_object.tests_passed:

--- a/loader/methods/pytest.py
+++ b/loader/methods/pytest.py
@@ -149,50 +149,56 @@ class PytestLoader:
                 self.redis.lrem("running_jobs", 0, job)
                 self.redis.delete("job_" + self.data['job_id'])
 
-                # in case if 'stopTestRun' was caught, but some running test exists
-                if job_object.tests_in_progress is not None:
-                    tests = job_object.tests.filter(status=2)  # 'In progress' tests must become 'Aborted'
-                    aborted_tests = 0
-                    for test in tests:
-                        test.status = 6
-                        test.save()
-                        aborted_tests += 1
-                    job_object.status = 3   # Failed
-                    job_object.tests_aborted = aborted_tests
-                # in case if 'stopTestRun' was caught and at least one test was failed
-                elif job_object.tests_failed is not None:
-                    job_object.status = 3   # Failed
-                # in case if 'stopTestRun' was caught and at least one test was aborted
-                elif job_object.tests_aborted is not None:
-                    job_object.status = 3   # Failed
-                # in case if 'stopTestRun' was caught and some tests remain not started
-                else:
-                    if job_object.tests_not_started is not None:
-                        tests = job_object.tests.filter(status=1)
-                        tests_not_started = 0
+                failed = job_object.tests_failed
+                not_started = job_object.tests_not_started
+
+                # If any "aborted" test case:
+                # Job status = Aborted
+                # Every "in progress" tests becomes - aborted
+
+                tests = job_object.tests.filter(status=2)
+                if job_object.tests.filter(status=6).first():
+                    job_object.status = 4
+                    if tests:
+                        aborted_tests = 0
                         for test in tests:
-                            tests_not_started += 1
-                        job_object.tests_not_started = tests_not_started
-                        job_object.status = 3   # Failed
-                    if job_object.tests_skipped is not None:
-                        # No fails, passed exist
-                        if job_object.tests_not_started is None and \
-                                job_object.tests_aborted is None and \
-                                job_object.tests_failed is None and \
-                                job_object.tests_passed is not None:
-                            job_object.status = 2   # Passed
-                        # Fails exist
-                        elif job_object.tests_not_started is not None or \
-                                job_object.tests_aborted is not None or \
-                                job_object.tests_failed is not None:
-                            job_object.status = 3  # Failed
-                        else:
-                            # No passed, no fails
-                            job_object.status = 5  # Skipped
+                            test.status = 6
+                            test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                            test.time_taken = test.stop_time - test.start_time
+                            test.save()
+                            aborted_tests += 1
+                        job_object.tests_aborted = aborted_tests
+                # If any "failed" test case:
+                # Job status = Failed
+                # Every "in progress" tests becomes - aborted
+                elif failed:
+                    job_object.status = 3
+                    if tests:
+                        aborted_tests = 0
+                        for test in tests:
+                            test.status = 6
+                            test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                            test.time_taken = test.stop_time - test.start_time
+                            test.save()
+                            aborted_tests += 1
+                        job_object.tests_aborted = aborted_tests
+                else:
+                    # If no "failed" test cases, but "not started" remain - job will be "Failed"
+                    if not_started:
+                        if tests:
+                            aborted_tests = 0
+                            for test in tests:
+                                test.status = 6
+                                test.stop_time = unix_time_to_datetime(self.data['stopTime'])
+                                test.time_taken = test.stop_time - test.start_time
+                                test.save()
+                                aborted_tests += 1
+                            job_object.tests_aborted = aborted_tests
+                        job_object.status = 3
+                    # If no "failed" (and other negative variations) test cases - job will be "Passed"
                     else:
-                        # if no tests with 'failed', 'aborted' or 'running' states after 'stopTestRun' signal -
-                        # mark job as 'Passed'
-                        job_object.status = 2   # Passed
+                        job_object.status = 2
+
                 job_object.stop_time = unix_time_to_datetime(self.data['stopTime'])
                 job_object.time_taken = job_object.stop_time - job_object.start_time
 
@@ -231,7 +237,7 @@ class PytestLoader:
 
             if job_object.status == 1:
                 try:
-                    test = Tests.objects.get(test__identity=self.data['test'], job=job_object)
+                    test = Tests.objects.get(uuid=self.data['uuid'], job=job_object)
                     test.status = 2
                     test.start_time = unix_time_to_datetime(self.data['startTime'])
                     test.save()
@@ -257,7 +263,7 @@ class PytestLoader:
             job_object = TestJobs.objects.get(uuid=self.data['job_id'])
             if job_object.status == 1:
                 try:
-                    test = Tests.objects.get(test__identity=self.data['test'], job=job_object)
+                    test = Tests.objects.get(uuid=self.data['uuid'], job=job_object)
                     if self.data['status'] == "passed":
                         test.status = 3
                         if not job_object.tests_passed:

--- a/loader/models.py
+++ b/loader/models.py
@@ -133,6 +133,8 @@ class Tests(models.Model):
         return timezone.localtime(self.start_time).strftime('%d-%b-%Y, %H:%M:%S')
 
     def get_stop_time(self):
+        if self.stop_time is None:
+            return None
         return timezone.localtime(self.stop_time).strftime('%d-%b-%Y, %H:%M:%S')
 
     def get_time_taken(self):

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -147,11 +147,11 @@
                                class="ui green basic label">{{ job.tests_passed }}</a>
                         {% endif %}
                         {% if job.tests_failed %}
-                            <a href="job/{{ job.uuid }}/#table_negative_tests"
+                            <a href="job/{{ job.uuid }}/#table_failed_tests"
                                class="ui red basic label status_failed">{{ job.tests_failed }}</a>
                         {% endif %}
                         {% if job.tests_aborted %}
-                            <a href="job/{{ job.uuid }}/#table_negative_tests"
+                            <a href="job/{{ job.uuid }}/#table_aborted_tests"
                                class="ui darkred basic label">{{ job.tests_aborted }}</a>
                         {% endif %}
                         {% if job.tests_skipped %}

--- a/main/templates/main/job.html
+++ b/main/templates/main/job.html
@@ -133,14 +133,14 @@
                     </span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                     <span id="job_tests_failed">
                     {% if status != 1 %}
-                        <a href="#table_negative_tests">Failed: <span class="{% if failed > 0 %}test_failed{% else %}{% endif %}">{{ failed }}</span></a>
+                        <a href="#table_failed_tests">Failed: <span class="{% if failed > 0 %}test_failed{% else %}{% endif %}">{{ failed }}</span></a>
                     {% else %}
                         Failed: <span class="{% if failed > 0 %}test_failed{% else %}{% endif %}">{{ failed }}</span>
                     {% endif %}
                     </span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
                     <span id="job_tests_aborted">
                     {% if status != 1 %}
-                        <a href="#table_negative_tests">Aborted: <span class="{% if aborted > 0 %}test_failed{% else %}{% endif %}">{{ aborted }}</span></a>
+                        <a href="#table_aborted_tests">Aborted: <span class="{% if aborted > 0 %}test_aborted{% else %}{% endif %}">{{ aborted }}</span></a>
                     {% else %}
                         Aborted: <span class="{% if aborted > 0 %}test_failed{% else %}{% endif %}">{{ aborted }}</span>
                     {% endif %}
@@ -261,8 +261,8 @@
         {% endif %}
 
     {% if status != 1 %}
-        {% if negative_tests > 0 %}
-        <a class="ui red ribbon label" id="table_negative_tests">Failed tests: {{ negative_tests }}</a>
+        {% if failed > 0 %}
+        <a class="ui red ribbon label" id="table_failed_tests">Failed tests: {{ failed }}</a>
         <table class="ui very basic selectable table">
             <thead>
             <tr>
@@ -275,7 +275,7 @@
             </thead>
             <tbody id="tests_list">
             {% for item in tests.all %}
-                {% if item.status != 3 and item.status != 1 and item.status != 5 %}
+                {% if item.status != 3 and item.status != 1 and item.status != 5 and item.status != 6%}
                 <tr class="ui negative" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}
                     <td>&nbsp;&nbsp;
@@ -297,9 +297,7 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if item.status == 4 %}<span class="ui red basic label">Failed</span>
-                        {% elif item.status == 6 %}<div class="ui red basic label">Aborted</div>
-                        {% endif %}
+                        <span class="ui red basic label">Failed</span>
                     </td>
                     <td>
                         <i title="Add a note" class="sticky note {% if not item.test.note %}outline{% endif %} large icon
@@ -360,6 +358,57 @@
                     </td>
                 </tr>
             {% endif %}
+            {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+
+        {% if aborted > 0 %}
+        <a class="ui red ribbon label" id="table_aborted_tests">Aborted tests: {{ aborted }}</a>
+        <table class="ui very basic selectable table">
+            <thead>
+            <tr>
+                <th>&nbsp;&nbsp;Test</th>
+                <th>Start Time</th>
+                <th>Time Taken</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody id="tests_list">
+            {% for item in tests.all %}
+                {% if item.status == 6 %}
+                <tr class="ui negative" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
+                    {% if fw == 1 %}
+                    <td>&nbsp;&nbsp;
+                        {{ item.test.get_test_method_for_nose }}</td>
+                    {% elif fw == 2 %}
+                    <td>&nbsp;&nbsp;
+                        {{ item.test.get_test_method_for_pytest }}</td>
+                    {% endif %}
+                    <td>
+                        {% if item.get_start_time is not None %}
+                            {{ item.get_start_time }}
+                        {% else %}0s
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if item.get_time_taken is not None %}
+                            {{ item.get_time_taken }}
+                        {% else %}0s
+                        {% endif %}
+                    </td>
+                    <td>
+                        <div class="ui red basic label">Aborted</div>
+                    </td>
+                    <td>
+                        <i title="Add a note" class="sticky note {% if not item.test.note %}outline{% endif %} large icon
+                        {% if item.test.note %}note_style_filled
+                        {% else %}note_style{% endif %}"
+                           data-name="note" data-id="{{ item.test.identity }}"></i>
+                    </td>
+                </tr>
+                {% endif %}
             {% endfor %}
             </tbody>
         </table>

--- a/main/templates/main/test.html
+++ b/main/templates/main/test.html
@@ -91,10 +91,39 @@
         <div class="ui list">
         {% for item in last_10_tests %}
             <div class="item">
-               <p> <i class="{% if item.1 == 4 or item.1 == 6 %}circle red{% elif item.1 == 3 %}circle green
-                           {% elif item.1 == 5 %}circle yellow{% elif item.1 == 1 or item.1 == 2 %}circle grey{% endif %} icon"></i>
-                <a href="{% url 'test' test_uuid=item.0 %}">{% if item.2 == None %}Final time not saved{% else %}{{item.2}}{% endif %}</a>
-                   {% if item.0 in request.path   %}<i class="arrow alternate circle left outline icon"></i>{% endif %}
+               <p>
+
+               {% comment %}
+               item.0 = uuid
+               item.1 = status
+               item.2 = stop_time
+               {% endcomment %}
+
+                   <i class="
+                    {% comment %} Status: Failed or Aborted {% endcomment %}
+                    {% if item.1 == 4 or item.1 == 6 %}circle red
+                    {% comment %} Status: Passed {% endcomment %}
+                    {% elif item.1 == 3 %}circle green
+                    {% comment %} Status: Skipped {% endcomment %}
+                    {% elif item.1 == 5 %}circle yellow
+                    {% comment %} Status: Not started {% endcomment %}
+                    {% elif item.1 == 1%}circle grey
+                    {% comment %} Status: Running {% endcomment %}
+                    {% elif item.1 == 2%}circle blue
+                    {% endif %} icon"></i>
+
+                    <a href="{% url 'test' test_uuid=item.0 %}">
+                    {% comment %} status: Not started, stop_time: None {% endcomment %}
+                    {% if item.1 == 1 and item.2 == None %}Not started
+                    {% comment %} status: Running, stop_time: None {% endcomment %}
+                    {% elif item.1 == 2 and item.2 == None %}Running
+                    {% comment %} status: Aborted, stop_time: None {% endcomment %}
+                    {% elif item.1 == 6 and item.2 == None %}Unknown date
+                    {% else %}{{item.2}}
+                    {% endif %}
+                    </a>
+
+                    {% if item.0 in request.path %}<i class="arrow alternate circle left outline icon"></i>{% endif %}
                </p>
             </div>
         {% endfor %}
@@ -175,7 +204,11 @@
                                 {% endif %}
                                 </div>
                                 <div class="item">
+                                    {% if storage_data.get_time_taken_eta is not None %}
                                     {{ storage_data.get_time_taken_eta }}
+                                    {% else %}
+                                        Data is yet unknown
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>

--- a/management/views.py
+++ b/management/views.py
@@ -23,7 +23,7 @@ def main(request):
 
 def about(request):
 
-    version = "0.18.0"
+    version = "0.18.1"
     response = requests.get(f"https://api.github.com/repos/and-sm/testgr/releases/latest",
                             headers={"Content-Type": "application/json", "User-Agent": "testgr"})
     if response.status_code != 200:


### PR DESCRIPTION
Fix: Correct timings and statuses for "Last N results" block.
Fix: Crash while opening test without "ETA" information.
Fix: Session authentication for /api/environment.
Refactor: Optimizations for nose2/pytest loaders.
Refactor: Failed and aborted tests are separated on "Job" page.