### PR TITLE
1.6.0

### DIFF
--- a/history/templates/history/history.html
+++ b/history/templates/history/history.html
@@ -6,7 +6,36 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
+
+<style>
+
+.ui.darkred.label,.ui.darkred.labels .label {
+    background-color: #a62525 !important;
+    border-color: #a62525!important;
+    color: #fff!important;
+}
+.ui.darkred.labels .label:hover,a.ui.darkred.label:hover{
+    background-color: #952424 !important;border-color:#952424!important;color:#fff!important
+}
+
+.ui.darkred.corner.label,.ui.darkred.corner.label:hover{
+    background-color:transparent!important
+}
+
+.ui.darkred.ribbon.label{
+    border-color:#b21e1e!important
+}
+
+.ui.basic.darkred.label{
+    background:none #fff!important;color:#a62525!important;border-color:#a62525!important
+}
+
+.ui.basic.darkred.labels a.label:hover,a.ui.basic.darkred.label:hover{
+    background-color:#fff!important;color:#d01919!important;border-color:#d01919!important
+}
+
+</style>
 
 </head>
 
@@ -81,11 +110,26 @@
                 <td>{{ job.get_time_taken }}</td>
                 <td>{{ job.get_env }}</td>
                 <td>
-                    {% if job.status == 2 %}<span class="ui green basic label">Passed</span>
-                    {% elif job.status == 3 %}<span class="ui red basic label">Failed</span>
-                    {% elif job.status == 4 %}<span class="ui yellow basic label">Stopped</span>
-                    {% elif job.status == 5 %}<span class="ui yellow basic label">Skipped</span>
-                    {% endif %}
+                        {% if job.tests_passed %}
+                            <a href="job/{{ job.uuid }}/#table_success_tests"
+                               class="ui green basic label">{{ job.tests_passed }}</a>
+                        {% endif %}
+                        {% if job.tests_failed %}
+                            <a href="job/{{ job.uuid }}/#table_failed_tests"
+                               class="ui red basic label status_failed">{{ job.tests_failed }}</a>
+                        {% endif %}
+                        {% if job.tests_aborted %}
+                            <a href="job/{{ job.uuid }}/#table_aborted_tests"
+                               class="ui darkred basic label">{{ job.tests_aborted }}</a>
+                        {% endif %}
+                        {% if job.tests_skipped %}
+                            <a href="job/{{ job.uuid }}/#table_skipped_tests"
+                               class="ui yellow basic label">{{ job.tests_skipped }}</a>
+                        {% endif %}
+                        {% if job.tests_not_started %}
+                            <a href="job/{{ job.uuid }}/#table_not_started_tests"
+                               class="ui grey basic label">{{ job.tests_not_started }}</a>
+                        {% endif %}
                 </td>
             </tr>
             {% endfor %}
@@ -156,7 +200,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 <script type="application/javascript" src="{% static 'js/testgr/main/running_jobs_count.js' %}"></script>
 

--- a/loader/methods/nose2.py
+++ b/loader/methods/nose2.py
@@ -47,7 +47,10 @@ class Nose2Loader:
                 try:
                     env = Environments.objects.get(name="None")
                     # Env name for Redis
-                    env_name = env.name
+                    if env.remapped_name:
+                        env_name = env.remapped_name
+                    else:
+                        env_name = env.name
                 except ObjectDoesNotExist:
                     env = Environments(name="None")
                     env.save()

--- a/loader/methods/pytest.py
+++ b/loader/methods/pytest.py
@@ -47,7 +47,10 @@ class PytestLoader:
                 try:
                     env = Environments.objects.get(name="None")
                     # Env name for Redis
-                    env_name = env.name
+                    if env.remapped_name:
+                        env_name = env.remapped_name
+                    else:
+                        env_name = env.name
                 except ObjectDoesNotExist:
                     env = Environments(name="None")
                     env.save()

--- a/main/templates/main/index.html
+++ b/main/templates/main/index.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html">
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
 <style>
 .ui.darkred.label,.ui.darkred.labels .label {
@@ -314,7 +314,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 <script type="application/javascript" src="{% static 'js/testgr/main/running_jobs_count.js' %}"></script>
 <script type="application/javascript" src="{% static 'js/testgr/main/latest_jobs.js' %}"></script>

--- a/main/templates/main/job.html
+++ b/main/templates/main/job.html
@@ -7,7 +7,7 @@
 {% load static %}
 {% load urlize_target_blank %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css" />
 
 
 <style>
@@ -108,7 +108,7 @@
         <div><h5>Custom data: </h5>
         <div class="ui bulleted list">
         {% for key, value in custom_data %}
-            <div class="item"><strong>{{ key }}: </strong>{{ value|urlize|urlize_target_blank }}</div>
+            <div class="item" style="word-wrap: break-word;"><strong>{{ key }}: </strong>{{ value|urlize|urlize_target_blank }}</div>
         {% endfor %}
         </div>
         </div>
@@ -829,7 +829,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.9.3/Chart.bundle.min.js"></script>
 
 <script>

--- a/main/templates/main/login.html
+++ b/main/templates/main/login.html
@@ -6,7 +6,7 @@
 <meta http-equiv="Content-Type" content="text/html">
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
 
 <style type="text/css">
@@ -100,6 +100,6 @@
 
 </body>
 
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 </html>

--- a/main/templates/main/test.html
+++ b/main/templates/main/test.html
@@ -7,9 +7,10 @@
 {% load static %}
 {% load urlize_target_blank %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
     <style>
+
         .identity{
             word-wrap: break-word;
         }
@@ -152,12 +153,18 @@
 
     <div class="eleven wide column identity">
 
+    <div class="ui grid">
+
+        <div class="ui ten wide column">
         <span class="ui accordion">
-            <span class="title ui large blue text">{{ test_class }}:<strong>{{ test_method }}</strong></span>
+            <span class="title ui large blue text">
+                {{ test_class }}:<strong>{{ test_method }}</strong>
+                <i class="caret down icon" id="accordion_caret"></i>
+            </span>
             <div class="content">
                 <div class="ui row>"></div>
                 <h4>Execution path:</h4>
-            <div  class="transition hidden">
+            <div class="transition hidden">
                 {% for i in identity %}
                     {% if forloop.last %}
                         {% if status == 1 %}
@@ -182,6 +189,21 @@
             </div>
             </div>
         </span>
+        </div>
+
+        <div class="ui six wide column right aligned">
+            <button class="ui grey basic button" id="btn_copy_method" data-clipboard-text="{{ test_method }}">
+                <i class="copy outline icon"></i>
+                Copy test name
+            </button>
+            <button class="ui grey basic button" id="btn_copy_path" data-clipboard-text="{{ full_path }}">
+                <i class="copy outline icon"></i>
+                Copy test full path
+            </button>
+        </div>
+
+    </div>
+
 
         <div class="ui divider"></div>
 
@@ -247,6 +269,8 @@
                                 </div>
                                 <div class="item"><strong>Time taken:</strong>
                                 </div>
+                                <div class="item"><strong>Custom data:</strong>
+                                </div>
                             </div>
                         </div>
 
@@ -263,6 +287,12 @@
                                 </div>
                                 <div class="item">
                                     {% if time_taken is not None %}{{ time_taken }}{% else %}Pending...{% endif %}
+                                </div>
+                                <div class="item">
+                                    {% for key, value in custom_data %}
+                                        <div class="item" style="word-wrap: break-word;"><strong>{{ key }}:
+                                        </strong>{{ value|urlize|urlize_target_blank }}</div>
+                                    {% endfor %}
                                 </div>
                             </div>
                         </div>
@@ -285,7 +315,7 @@
                                 </div>
                                 <div class="item"><strong>Last fail:</strong>
                                 </div>
-                                <div class="item"><strong>Time based on last 3 attempts:</strong></div>
+                                <div class="item"><strong>Exec. time based on last 3 attempts:</strong></div>
                             </div>
                         </div>
                         <div class="six wide column">
@@ -306,6 +336,52 @@
                                     {% endif %}
                                 </div>
                             </div>
+                        </div>
+                    </div>
+
+                    <div class="ui divider"></div>
+
+                    <h3 class="ui header">
+                        <i class="route icon"></i>
+                        <div class="content">Navigation</div>
+                    </h3>
+
+                    <div class="ui row">&nbsp;</div>
+
+                    <div class="ui grid">
+                        <div class="twelve wide column">
+                                {% if previous_result %}<a href="{% url 'test' test_uuid=previous_result.uuid %}">{% endif %}
+                                <button class="ui basic {% if previous_result.status == 1 %}grey
+                                                        {% elif previous_result.status == 2 %}blue
+                                                        {% elif previous_result.status == 3 %}green
+                                                        {% elif previous_result.status == 4 %}red
+                                                        {% elif previous_result.status == 5 %}yellow
+                                                        {% elif previous_result.status == 6 %}red
+                                                        {% endif %} labeled icon button
+                                {% if not previous_result.stop_time %}disabled{% endif %}">
+                                    <i class="left chevron icon"></i>
+                                    Previous result {% if previous_result.stop_time %}<br />
+                                    ({{ previous_result.stop_time }}){% else %}<br />&nbsp;{% endif %}
+                                </button>{% if previous_result %}</a>{% endif %}
+                                {% if next_result %}<a href="{% url 'test' test_uuid=next_result.uuid %}">{% endif %}
+                                <button class="ui basic {% if next_result.status == 1 %}grey
+                                                        {% elif next_result.status == 2 %}blue
+                                                        {% elif next_result.status == 3 %}green
+                                                        {% elif next_result.status == 4 %}red
+                                                        {% elif next_result.status == 5 %}yellow
+                                                        {% elif next_result.status == 6 %}red
+                                                        {% endif %} right labeled icon button
+                                {% if not next_result.stop_time %}disabled{% endif %}">
+                                    Next result {% if next_result.stop_time %}<br />({{ next_result.stop_time }})
+                                {% else %}<br />&nbsp;{% endif %}
+                                    <i class="right chevron icon"></i>
+                                </button>{% if next_result %}</a>{% endif %}
+                            </div>
+                        <div class="four wide column right aligned">
+                            <a href="{% url 'job' test_job.uuid %}"><button class="ui basic grey button">
+                                <i class="level up alternate icon"></i><br />
+                                Open job
+                            </button></a>
                         </div>
                     </div>
 
@@ -345,6 +421,8 @@
 
             </div>
 
+    </div>
+
     <div class="one wide column">
     </div>
 
@@ -353,14 +431,41 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
 
 <script type="application/javascript" src="{% static 'js/testgr/main/running_jobs_count.js' %}"></script>
 
 <script>
 $('.ui.accordion')
-  .accordion()
-;
+  .accordion({
+
+      onChanging: function()
+      {
+          if($('#accordion_caret').attr('class') === 'caret up icon') {
+              $('#accordion_caret').attr('class', 'caret down icon')
+          }
+          else{
+              $('#accordion_caret').attr('class', 'caret up icon')
+              }
+          }
+  }
+)
+</script>
+
+<script>
+new ClipboardJS('#btn_copy_method');
+</script>
+
+<script>
+new ClipboardJS('#btn_copy_path');
+</script>
+
+<script>
+$("#btn_copy_path").on("click", function() {$("#btn_copy_path").transition('pulse');
+});
+$("#btn_copy_method").on("click", function() {$("#btn_copy_method").transition('pulse');
+});
 </script>
 
 </html>

--- a/management/templates/management/about.html
+++ b/management/templates/management/about.html
@@ -6,7 +6,7 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
 </head>
 
@@ -86,7 +86,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 <script type="application/javascript" src="{% static 'js/testgr/main/running_jobs_count.js' %}"></script>
 

--- a/management/templates/management/main.html
+++ b/management/templates/management/main.html
@@ -6,7 +6,7 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
 </head>
 
@@ -122,7 +122,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 <script>
 $("div[data-create-btn]").click(function () {

--- a/management/templates/management/users.html
+++ b/management/templates/management/users.html
@@ -6,7 +6,7 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
 </head>
 

--- a/management/templates/management/users_add.html
+++ b/management/templates/management/users_add.html
@@ -6,7 +6,7 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
 
 </head>
 
@@ -117,7 +117,7 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
 
 <script>
 $("div[data-create-btn]").click(function () {

--- a/management/views.py
+++ b/management/views.py
@@ -24,7 +24,7 @@ def main(request):
 @login_required()
 def about(request):
 
-    version = "1.5.1"
+    version = "1.6.0"
     response = requests.get(f"https://api.github.com/repos/and-sm/testgr/releases/latest",
                             headers={"Content-Type": "application/json", "User-Agent": "testgr"})
     if response.status_code != 200:

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -6,13 +6,38 @@
 
 {% load static %}
 
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.css">
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.20/css/dataTables.semanticui.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.css">
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.21/css/dataTables.semanticui.min.css">
 
 <style>
 
 .table{
  display:none;
+}
+
+.ui.darkred.label,.ui.darkred.labels .label {
+    background-color: #a62525 !important;
+    border-color: #a62525!important;
+    color: #fff!important;
+}
+.ui.darkred.labels .label:hover,a.ui.darkred.label:hover{
+    background-color: #952424 !important;border-color:#952424!important;color:#fff!important
+}
+
+.ui.darkred.corner.label,.ui.darkred.corner.label:hover{
+    background-color:transparent!important
+}
+
+.ui.darkred.ribbon.label{
+    border-color:#b21e1e!important
+}
+
+.ui.basic.darkred.label{
+    background:none #fff!important;color:#a62525!important;border-color:#a62525!important
+}
+
+.ui.basic.darkred.labels a.label:hover,a.ui.basic.darkred.label:hover{
+    background-color:#fff!important;color:#d01919!important;border-color:#d01919!important
 }
 
 </style>
@@ -198,7 +223,7 @@
                 <th>Stop DateTime</th>
                 <th>Time Taken</th>
                 <th>Environment</th>
-                <th>Job Status</th>
+                <th>Tests</th>
             </tr>
             </thead>
             <tbody></tbody>
@@ -207,7 +232,7 @@
                 <th>Stop DateTime</th>
                 <th>Time Taken</th>
                 <th>Environment</th>
-                <th>Job Status</th>
+                <th>Tests</th>
             </tr>
             </tfoot>
         </table>
@@ -223,9 +248,9 @@
 </body>
 
 <script type="application/javascript" src="{% static 'js/jquery.min.js' %}"></script>
-<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.4/dist/semantic.min.js"></script>
-<script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js" type="text/javascript"></script>
-<script src="https://cdn.datatables.net/1.10.20/js/dataTables.semanticui.min.js" type="text/javascript"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.8.6/dist/semantic.min.js"></script>
+<script src="https://cdn.datatables.net/1.10.21/js/jquery.dataTables.min.js" type="text/javascript"></script>
+<script src="https://cdn.datatables.net/1.10.21/js/dataTables.semanticui.min.js" type="text/javascript"></script>
 
 
 <script>
@@ -267,7 +292,7 @@ $('#filter_btn').click(function(event){
             { "data": "Stop DateTime" },
             { "data": "Time Taken" },
             { "data": "Environment" },
-            { "data": "Job Status" }
+            { "data": "Tests" }
         ],
         "rowCallback": function (nRow, aData, iDisplayIndex, iDisplayIndexFull) {
             let id = aData.uuid;

--- a/search/views.py
+++ b/search/views.py
@@ -53,7 +53,7 @@ def filter_data(request):
     for each_arg in args_list:
         args.add(each_arg, conn_type='AND')
 
-    query_set = TestJobs.objects.filter(*(args,)).order_by('-stop_time')
+    query_set = TestJobs.objects.filter(*(args,)).order_by('-stop_time').exclude(status=1)
     # will excute, query_set.filter(Q1 | Q2 | Q3)
     # comma , in last after args is mandatory to pass as args here
 
@@ -70,24 +70,28 @@ def filter_data(request):
         # Environment
         env = item.get_env()
 
-        # Status
-        status = item.status
-
-        if status == 1:
-            status = "<td><span class=\"ui blue basic label\">Running</span></td>"
-        elif status == 2:
-            status = "<td><span class=\"ui green basic label\">Passed</span></td>"
-        elif status == 3:
-            status = "<td><span class=\"ui red basic label\">Failed</span></td>"
-        elif status == 4:
-            status = "<td><span class=\"ui yellow basic label\">Stopped</span></td>"
-        elif status == 5:
-            status = "<td><span class=\"ui yellow basic label\">Skipped</span></td>"
+        # Tests
+        tests = ""
+        if item.tests_passed:
+            tests = '<a href="job/{{ job.uuid }}/#table_success_tests" class="ui green basic label">'\
+                    + str(item.tests_passed) + '</a>'
+        if item.tests_failed:
+                tests += '<a href="job/{{ job.uuid }}/#table_failed_tests" class="ui red basic label">'\
+                    + str(item.tests_failed) + '</a>'
+        if item.tests_skipped:
+                tests += '<a href="job/{{ job.uuid }}/#table_skipped_tests" class="ui yellow basic label">'\
+                    + str(item.tests_skipped) + '</a>'
+        if item.tests_aborted:
+                tests += '<a href="job/{{ job.uuid }}/#table_aborted_tests" class="ui darkred basic label">'\
+                    + str(item.tests_aborted) + '</a>'
+        if item.tests_not_started:
+                tests += '<a href="job/{{ job.uuid }}/#table_not_started_tests" class="ui grey basic label">'\
+                    + str(item.tests_not_started) + '</a>'
 
         uuid = item.uuid
 
         datatable_dict.append({'Stop DateTime': stop_time, 'Time Taken': time_taken,
-                               'Environment': env, 'Job Status': status, 'uuid': uuid})
+                               'Environment': env, 'Tests': tests, 'uuid': uuid})
 
     test_data = {"data": datatable_dict}
 


### PR DESCRIPTION
**New**: Tests info with multiple statuses added to Search and History pages instead of deprecated 'Status' column.
**New**: Test details page: Job custom data added.
**New**: Test details page: "Copy test name" and "Copy test full path" buttons.
**New**: Test details page: Navigation block to simplify browsing between results of the same test and different jobs.
**Fix**: Mapped name for "None" environment wasn't send via websocket.
**Fix**: Search is broken while filtering table with existing running job.
**Fix**: Running jobs list: "None" removed for "not running tests" count.
**Fix**: Wrap for custom data with long text.

**Components update**:
Fomantic UI 2.8.6
DataTables 1.10.21
