### PR TITLE
Add prefetch test__bugs for job page

### DIFF
--- a/main/templates/main/job.html
+++ b/main/templates/main/job.html
@@ -253,7 +253,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 <tr onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';"
                     class="ui
                     {% if item.status == 1%}{% endif %}
@@ -345,7 +345,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 {% if item.status != 3 and item.status != 1 and item.status != 5 and item.status != 6%}
                 <tr class="ui negative" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}
@@ -428,7 +428,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 {% if item.status == 3 %}
                 <tr class="ui positive" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}
@@ -510,7 +510,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 {% if item.status == 6 %}
                 <tr class="ui negative" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}
@@ -592,7 +592,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 {% if item.status == 5 %}
                 <tr class="ui warning" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}
@@ -674,7 +674,7 @@
             </tr>
             </thead>
             <tbody id="tests_list">
-            {% for item in tests.all %}
+            {% for item in tests %}
                 {% if item.status == 1 %}
                 <tr class="ui" onclick="window.location.href = '{% url 'test' test_uuid=item.uuid %}';">
                     {% if fw == 1 %}

--- a/main/views.py
+++ b/main/views.py
@@ -108,7 +108,7 @@ def job(request, job_uuid):
         files = files
 
     status = job_object.status
-    tests = job_object.tests.select_related('test')
+    tests = job_object.tests.select_related('test').prefetch_related('test__bugs')
 
     # Statistics
     not_started = int(job_object.tests_not_started or 0)

--- a/management/views.py
+++ b/management/views.py
@@ -27,7 +27,7 @@ def main(request):
 @staff_member_required
 def about(request):
 
-    version = "1.14.1"
+    version = "1.14.2"
 
     response = requests.get(f"https://api.github.com/repos/and-sm/testgr/releases/latest",
                             headers={"Content-Type": "application/json", "User-Agent": "testgr"})


### PR DESCRIPTION
Without prefetch it takes O(n) (n = test number) requests to database to render `/job/*` page. With this PR it takes 7 queries constantly.